### PR TITLE
Empty data table for no column field

### DIFF
--- a/src/js/orb.ui.pgridwidget.js
+++ b/src/js/orb.ui.pgridwidget.js
@@ -174,7 +174,8 @@ module.exports = function(config) {
         if(dataCell) {
             var colIndexes = dataCell.columnDimension.getRowIndexes();
             var data = dataCell.rowDimension.getRowIndexes().filter(function(index) {
-                return colIndexes.indexOf(index) >= 0;
+                //return colIndexes.indexOf(index) >= 0;
+                return (colIndexes.length === 0 ) || (colIndexes.indexOf(index) >= 0);
             }).map(function(index) {
                 return self.pgrid.filteredDataSource[index];
             });


### PR DESCRIPTION
When there no field in column area, then double click on data cell displays empty table
Added code to get filtered data even if the colIndexes has 0 length